### PR TITLE
Fix Optional import

### DIFF
--- a/fraud_detection/config.py
+++ b/fraud_detection/config.py
@@ -1,7 +1,7 @@
 """Configuration management for fraud detection system."""
 
 import os
-from typing import Dict, Any
+from typing import Dict, Any, Optional
 import yaml
 from pydantic import BaseSettings, Field
 from pathlib import Path


### PR DESCRIPTION
## Summary
- add `Optional` typing hint import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx'; Pydantic import errors)*

------
https://chatgpt.com/codex/tasks/task_e_68445aa4786c832182d92930f6e3a1c7